### PR TITLE
chore: add readme entry for timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ const { peerId, source } = await getIndexProviderPeerId(minerId, contract, {
   maxAttempts: 3, // Number of retry attempts (default: 5)
   rpcUrl: 'https://custom-filecoin-api.com', // Custom Filecoin RPC endpoint (default: 'https://api.node.glif.io/')
   rpcAuth: 'your-auth-token', // Optional authorization token for RPC
+  signal: AbortSignal, // Optional AbortSignal for cancellation
 })
 ```
 
@@ -51,7 +52,9 @@ const { peerId, source } = await getIndexProviderPeerId(minerId, contract, {
 - `options`: (Optional) Configuration object:
   - `maxAttempts`: Number of retry attempts for RPC calls (default: 5)
   - `rpcUrl`: Filecoin RPC endpoint URL (default: 'https://api.node.glif.io/')
-  - `rpcAuth`: Authorization token for RPC endpoint (if required)
+  - `rpcAuth`: Authorization token for RPC endpoint (if required)\
+  - `signal`: An AbortSignal object for cancelling the rpc request (Only effects the rpc call to the
+    Filecoin API, not the smart contract call)
 
 ### Return Value
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const { peerId, source } = await getIndexProviderPeerId(minerId, contract, {
   maxAttempts: 3, // Number of retry attempts (default: 5)
   rpcUrl: 'https://custom-filecoin-api.com', // Custom Filecoin RPC endpoint (default: 'https://api.node.glif.io/')
   rpcAuth: 'your-auth-token', // Optional authorization token for RPC
-  signal: AbortSignal, // Optional AbortSignal for cancellation
+  signal: AbortSignal.timeout(60_000), // Optional AbortSignal for cancellation
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const { peerId, source } = await getIndexProviderPeerId(minerId, contract, {
 - `options`: (Optional) Configuration object:
   - `maxAttempts`: Number of retry attempts for RPC calls (default: 5)
   - `rpcUrl`: Filecoin RPC endpoint URL (default: 'https://api.node.glif.io/')
-  - `rpcAuth`: Authorization token for RPC endpoint (if required)\
+  - `rpcAuth`: Authorization token for RPC endpoint (if required)
   - `signal`: An AbortSignal object for cancelling the rpc request (Only effects the rpc call to the
     Filecoin API, not the smart contract call)
 


### PR DESCRIPTION
Adds documentation for the abort signal introduces in https://github.com/CheckerNetwork/index-provider-peer-id/pull/18
Related to https://github.com/CheckerNetwork/spark-deal-observer/issues/145